### PR TITLE
Added tags display to post details

### DIFF
--- a/src/components/posts/ViewPostDetails.jsx
+++ b/src/components/posts/ViewPostDetails.jsx
@@ -74,6 +74,15 @@ export const ViewPostDetails = ({ token }) => {
             </button>
             <div className="post-content">{post.content}</div>
           </div>
+          <div className="tags">
+            {post.tags.map((postTag) => {
+              return (
+                <div className="tag is-info" key={postTag.id}>
+                  {postTag.tag.label}
+                </div>
+              );
+            })}
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Added list of tags to show at the bottom of post content

How to test
- pull `show-post-tags` API and run
- pull `show-post-tags` Client
- run npm start
- check post details pages and check that tags show up properly